### PR TITLE
minimize allocations when deserializing

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -100,7 +100,7 @@ func TestQuantiles(t *testing.T) {
 }
 
 func BenchmarkHistogramRecordValue(b *testing.B) {
-	h := hist.NewNoLocks()
+	h := hist.New(hist.NoLocks())
 	for i := 0; i < b.N; i++ {
 		h.RecordValue(float64(i % 1000))
 	}
@@ -108,7 +108,7 @@ func BenchmarkHistogramRecordValue(b *testing.B) {
 }
 
 func BenchmarkHistogramTypical(b *testing.B) {
-	h := hist.NewNoLocks()
+	h := hist.New(hist.NoLocks())
 	for i := 0; i < b.N; i++ {
 		h.RecordValue(float64(i % 1000))
 	}
@@ -116,7 +116,7 @@ func BenchmarkHistogramTypical(b *testing.B) {
 }
 
 func BenchmarkHistogramRecordIntScale(b *testing.B) {
-	h := hist.NewNoLocks()
+	h := hist.New(hist.NoLocks())
 	for i := 0; i < b.N; i++ {
 		h.RecordIntScale(int64(i%90+10), (i/1000)%3)
 	}
@@ -124,7 +124,7 @@ func BenchmarkHistogramRecordIntScale(b *testing.B) {
 }
 
 func BenchmarkHistogramTypicalIntScale(b *testing.B) {
-	h := hist.NewNoLocks()
+	h := hist.New(hist.NoLocks())
 	for i := 0; i < b.N; i++ {
 		h.RecordIntScale(int64(i%90+10), (i/1000)%3)
 	}


### PR DESCRIPTION
use functional options pattern for constructor

The functional options pattern is a common Go idiom that allows callers
to configure internals of a process without exposing them. The variadic
function signature allows this change to be backwards compatible, as
well.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

minimize allocations when deserializing

Histograms containing empty bins no longer serialize into empty byte
sequences and deserializing those histograms no longer allocates memory
for unused bins.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---