### PR TITLE
allow creating histograms without lookup tables

### DIFF
--- a/circonusllhist_test.go
+++ b/circonusllhist_test.go
@@ -329,6 +329,18 @@ func (t *value) run(histogram *Histogram) error {
 }
 
 func BenchmarkRecord(b *testing.B) {
+	benchmarkForHist(b, func() *Histogram {
+		return New()
+	})
+}
+
+func BenchmarkRecordWithoutLookups(b *testing.B) {
+	benchmarkForHist(b, func() *Histogram {
+		return New(NoLookup())
+	})
+}
+
+func benchmarkForHist(b *testing.B, constructor func() *Histogram) {
 	rand.Seed(time.Now().UnixNano())
 	for _, scale := range []int{1, 2, 4, 8, 16, 32, 64} {
 		for _, tester := range []preloadedTester{
@@ -337,7 +349,7 @@ func BenchmarkRecord(b *testing.B) {
 		} {
 			name := fmt.Sprintf("%T", tester)
 			b.Run(fmt.Sprintf("%s_%d", name[strings.Index(name, ".")+1:], scale), func(b *testing.B) {
-				histogram := New()
+				histogram := constructor()
 				tester.preload(b.N)
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {


### PR DESCRIPTION
In many cases when the number of histogram buckets is low, the sparse
lookup tables take up the vast majority of the memory footprint of the
histogram. This patch adds an option to allow users to create histograms
without lookup tables for buckets. The effect is to drastically reduce
the memory footprint of a histogram while only increasing insert time by
about 20%.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Here is the script I used to generate the benchmark data:

```sh
$ git checkout master
$ go test ./... -bench 'BenchmarkRecord' -benchtime 1000000x -count 100 > /tmp/before.txt
$ git checkout skuznets/no-lookup
$ go test ./... -bench 'BenchmarkRecord$' -benchtime 1000000x -count 100 > /tmp/with_lookups.txt
$ go test ./... -bench 'BenchmarkRecordWithoutLookups' -benchtime 1000000x -count 100 > /tmp/without_lookups.txt
$ sed -i 's/WithoutLookups//g' /tmp/without_lookups.txt # to allow comparison
```

The raw data are attached to this PR:
[before.txt](https://github.com/openhistogram/circonusllhist/files/6612152/before.txt)
[with_lookups.txt](https://github.com/openhistogram/circonusllhist/files/6612155/with_lookups.txt)
[without_lookups.txt](https://github.com/openhistogram/circonusllhist/files/6612156/without_lookups.txt)

Comparing the performance before any patches and with `New()` after this patch, we can see the effect of the new `if` checks and of using a slice instead of an array for the top level of the lookup table:

```
$ benchstat /tmp/before.txt /tmp/with_lookups.txt 
name                  old time/op  new time/op  delta
Record/intScale_1-8   44.1ns ±14%  45.0ns ±10%   +2.13%  (p=0.000 n=99+97)
Record/value_1-8      92.0ns ±74%  94.1ns ±83%     ~     (p=0.175 n=100+100)
Record/intScale_2-8   43.2ns ± 8%  50.5ns ±28%  +16.92%  (p=0.000 n=85+99)
Record/value_2-8      91.0ns ±37%  98.3ns ±32%   +7.96%  (p=0.001 n=100+100)
Record/intScale_4-8   43.8ns ±12%  46.3ns ±10%   +5.63%  (p=0.000 n=97+95)
Record/value_4-8      87.9ns ±41%  99.5ns ±32%  +13.16%  (p=0.000 n=100+100)
Record/intScale_8-8   43.9ns ±12%  45.0ns ± 6%   +2.63%  (p=0.000 n=96+94)
Record/value_8-8      93.4ns ±36%  90.8ns ±35%     ~     (p=0.175 n=100+100)
Record/intScale_16-8  42.8ns ± 3%  47.0ns ±12%   +9.60%  (p=0.000 n=81+100)
Record/value_16-8     90.6ns ±36%  89.4ns ±40%     ~     (p=0.779 n=100+100)
Record/intScale_32-8  44.2ns ±13%  45.0ns ± 7%   +1.93%  (p=0.000 n=99+93)
Record/value_32-8      114ns ±11%   113ns ±10%     ~     (p=0.596 n=100+97)
Record/intScale_64-8  42.8ns ± 3%  45.6ns ±10%   +6.44%  (p=0.000 n=80+96)
Record/value_64-8      112ns ± 7%   113ns ±14%     ~     (p=0.757 n=90+99)
```

We're inserting 1 million random values in each benchmark (and running 100 runs of 1 million insertions),  so I am surprised that there's a difference at all in these. That being said, perhaps there's something wrong with the benchmarks or, as most of the variation is in datasets with less variability, perhaps there are simply not enough individual bins to matter in those cases?

Here is the comparison between `New()` and `New(WithoutLookups())` in the current patch:

```
$ benchstat /tmp/with_lookups.txt /tmp/without_lookups.txt 
name                  old time/op  new time/op   delta
Record/intScale_1-8   45.0ns ±10%   49.6ns ± 2%  +10.25%  (p=0.000 n=97+83)
Record/value_1-8      94.1ns ±83%  109.7ns ±45%  +16.51%  (p=0.000 n=100+100)
Record/intScale_2-8   50.5ns ±28%   51.3ns ±12%     ~     (p=0.521 n=99+99)
Record/value_2-8      98.3ns ±32%  103.7ns ±51%     ~     (p=0.146 n=100+100)
Record/intScale_4-8   46.3ns ±10%   49.9ns ± 7%   +7.76%  (p=0.000 n=95+81)
Record/value_4-8      99.5ns ±32%  102.1ns ±51%     ~     (p=0.217 n=100+100)
Record/intScale_8-8   45.0ns ± 6%   53.5ns ±14%  +18.79%  (p=0.000 n=94+98)
Record/value_8-8      90.8ns ±35%  114.0ns ±50%  +25.52%  (p=0.000 n=100+100)
Record/intScale_16-8  47.0ns ±12%   52.3ns ±15%  +11.46%  (p=0.000 n=100+99)
Record/value_16-8     89.4ns ±40%  104.5ns ±65%  +16.92%  (p=0.000 n=100+100)
Record/intScale_32-8  45.0ns ± 7%   52.6ns ±20%  +16.80%  (p=0.000 n=93+98)
Record/value_32-8      113ns ±10%    144ns ±16%  +26.79%  (p=0.000 n=97+100)
Record/intScale_64-8  45.6ns ±10%   52.1ns ±22%  +14.36%  (p=0.000 n=96+98)
Record/value_64-8      113ns ±14%    142ns ± 9%  +25.06%  (p=0.000 n=99+94)
```

The decrease in insert efficiency  is more pronounced in datasets with larger variance, which is expected as that should be a rough proxy for the number of bins used, and the insert cost should increase roughly with the number of bins in the case where we're doing a binary search through the bins instead of using the lookup table.