### PR TITLE
Linting

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,24 @@
+name: golangci-lint
+on:
+  push:
+    tags: [ "v*" ]
+    branches: [ master ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          stable: true
+          go-version: 1.16.x
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.40
+          skip-go-installation: true
+          args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,80 @@
+run:
+  concurrency: 4
+  issues-exit-code: 1
+  tests: true
+  skip-dirs-use-default: true
+  skip-files:
+    - ".*_mock_test.go$"
+  allow-parallel-runners: true
+
+# all available settings of specific linters
+linters-settings:
+  govet:
+    check-shadowing: true
+    enable-all: true
+  gofmt:
+    simplify: true
+  gosec:
+    excludes: 
+      - G404
+  goimports:
+    local-prefixes: github.com/circonus-labs,github.com/openhistogram,github.com/circonus
+  misspell:
+    locale: US
+  unused:
+    check-exported: false
+  unparam:
+    check-exported: false
+  staticcheck:
+    go: "1.16"
+    # https://staticcheck.io/docs/options#checks
+    checks: [ "all", "-ST1017" ]
+  stylecheck:
+    go: "1.16"
+    # https://staticcheck.io/docs/options#checks
+    checks: [ "all", "-ST1017" ]
+
+linters:
+  enable:
+    - deadcode
+    - errcheck
+    - gocritic
+    - gofmt
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - megacheck
+    - misspell
+    - prealloc
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unparam
+    - unused
+    - varcheck
+    - gci
+    - godot
+    - godox
+    - goerr113
+    - predeclared
+    - unconvert
+    - wrapcheck
+    - revive
+    - exportloopref
+    - asciicheck
+    - errorlint
+    - wrapcheck
+    - goconst
+    #- stylecheck
+    - forcetypeassert
+    - goimports
+  disable:
+    - scopelint # deprecated
+    - golint    # deprecated
+    - maligned  # deprecated
+  disable-all: false
+  presets:
+    - bugs
+    - unused
+  fast: false


### PR DESCRIPTION
Add:

* lint configuration
* GitHub workflow to lint on commits/PRs

Addressed initial issues from lint. 

Currently, running clean.

```sh
golangci-lint run -v                                                                                                                                                                                                                             

INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 38 linters: [asciicheck bodyclose deadcode durationcheck errcheck errorlint exhaustive exportloopref forcetypeassert gci goconst gocritic godot godox goerr113 gofmt goimports gosec gosimple govet ineffassign makezero misspell nilerr noctx prealloc predeclared revive rowserrcheck sqlclosecheck staticcheck structcheck typecheck unconvert unparam unused varcheck wrapcheck]
INFO [lintersdb] Active presets: [bugs unused]
INFO [loader] Go packages loading at mode 575 (imports|types_sizes|deps|exports_file|files|name|compiled_files) took 184.277962ms
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 2.063441ms
INFO [linters context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 24, after processing: 0
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 24/24, exclude: 24/24, cgo: 24/24, skip_files: 24/24, skip_dirs: 24/24, filename_unadjuster: 24/24, exclude-rules: 15/24, path_prettifier: 24/24, identifier_marker: 24/24, nolint: 0/15
INFO [runner] processing took 3.640351ms with stages: nolint: 1.934714ms, exclude-rules: 1.071089ms, identifier_marker: 421.809µs, autogenerated_exclude: 80.896µs, path_prettifier: 64.582µs, skip_files: 33.295µs, skip_dirs: 23.163µs, cgo: 6.142µs, filename_unadjuster: 1.7µs, max_same_issues: 626ns, diff: 409ns, uniq_by_line: 393ns, max_from_linter: 316ns, source_code: 249ns, exclude: 237ns, severity-rules: 204ns, max_per_file_from_linter: 145ns, path_shortener: 142ns, sort_results: 131ns, path_prefixer: 109ns
INFO [runner] linters took 44.912809ms with stages: goanalysis_metalinter: 41.190871ms
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 4 samples, avg is 73.0MB, max is 73.3MB
INFO Execution took 243.731503ms
```